### PR TITLE
Infrastructure: I'll help you create an S3 bucket named "help-log-live" with similar security configurations and bes...

### DIFF
--- a/configs/infrastructure/main.tf
+++ b/configs/infrastructure/main.tf
@@ -4,8 +4,8 @@ provider "aws" {
 }
 
 # Create S3 Bucket with versioning and encryption
-resource "aws_s3_bucket" "logs_bucket" {
-  bucket = "live-logs-enabled"
+resource "aws_s3_bucket" "help_logs_bucket" {
+  bucket = "help-log-live"
 
   # Prevent accidental deletion of this S3 bucket
   lifecycle {
@@ -13,23 +13,24 @@ resource "aws_s3_bucket" "logs_bucket" {
   }
 
   tags = {
-    Name        = "live-logs-enabled"
+    Name        = "help-log-live"
     Environment = "production"
     Purpose     = "Logging"
+    Managed_by  = "Terraform"
   }
 }
 
 # Enable versioning
-resource "aws_s3_bucket_versioning" "logs_bucket_versioning" {
-  bucket = aws_s3_bucket.logs_bucket.id
+resource "aws_s3_bucket_versioning" "help_logs_bucket_versioning" {
+  bucket = aws_s3_bucket.help_logs_bucket.id
   versioning_configuration {
     status = "Enabled"
   }
 }
 
 # Enable server-side encryption
-resource "aws_s3_bucket_server_side_encryption_configuration" "logs_bucket_encryption" {
-  bucket = aws_s3_bucket.logs_bucket.id
+resource "aws_s3_bucket_server_side_encryption_configuration" "help_logs_bucket_encryption" {
+  bucket = aws_s3_bucket.help_logs_bucket.id
 
   rule {
     apply_server_side_encryption_by_default {
@@ -39,8 +40,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "logs_bucket_encry
 }
 
 # Block public access
-resource "aws_s3_bucket_public_access_block" "logs_bucket_public_access_block" {
-  bucket = aws_s3_bucket.logs_bucket.id
+resource "aws_s3_bucket_public_access_block" "help_logs_bucket_public_access_block" {
+  bucket = aws_s3_bucket.help_logs_bucket.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -48,13 +49,21 @@ resource "aws_s3_bucket_public_access_block" "logs_bucket_public_access_block" {
   restrict_public_buckets = true
 }
 
+# Enable logging for bucket access
+resource "aws_s3_bucket_logging" "help_logs_bucket_logging" {
+  bucket = aws_s3_bucket.help_logs_bucket.id
+
+  target_bucket = aws_s3_bucket.help_logs_bucket.id
+  target_prefix = "access-logs/"
+}
+
 # Output the bucket name and ARN
 output "bucket_name" {
-  value       = aws_s3_bucket.logs_bucket.id
+  value       = aws_s3_bucket.help_logs_bucket.id
   description = "The name of the bucket"
 }
 
 output "bucket_arn" {
-  value       = aws_s3_bucket.logs_bucket.arn
+  value       = aws_s3_bucket.help_logs_bucket.arn
   description = "The ARN of the bucket"
 }


### PR DESCRIPTION
This PR contains Terraform infrastructure generated by the IAC AI assistant.

**Generated from conversation:** I'll help you create an S3 bucket named "help-log-live" with similar security configurations and best practices.

```hcl
# Configure AWS Provider
provider "aws" {
  region = "us-east-1"
}

# Create S3 Bucket with versioning and encryption
resource "aws_s3_bucket" "help_logs_bucket" {
  bucket = "help-log-live"

  # Prevent accidental deletion of this S3 bucket
  lifecycle {
    prevent_destroy = true
  }

  tags = {
    Name        = "help-log-live"
    Environment = "production"
    Purpose     = "Logging"
    Managed_by  = "Terraform"
  }
}

# Enable versioning
resource "aws_s3_bucket_versioning" "help_logs_bucket_versioning" {
  bucket = aws_s3_bucket.help_logs_bucket.id
  versioning_configuration {
    status = "Enabled"
  }
}

# Enable server-side encryption
resource "aws_s3_bucket_server_side_encryption_configuration" "help_logs_bucket_encryption" {
  bucket = aws_s3_bucket.help_logs_bucket.id

  rule {
    apply_server_side_encryption_by_default {
      sse_algorithm = "AES256"
    }
  }
}

# Block public access
resource "aws_s3_bucket_public_access_block" "help_logs_bucket_public_access_block" {
  bucket = aws_s3_bucket.help_logs_bucket.id

  block_public_acls       = true
  block_public_policy     = true
  ignore_public_acls      = true
  restrict_public_buckets = true
}

# Enable logging for bucket access
resource "aws_s3_bucket_logging" "help_logs_bucket_logging" {
  bucket = aws_s3_bucket.help_logs_bucket.id

  target_bucket = aws_s3_bucket.help_logs_bucket.id
  target_prefix = "access-logs/"
}

# Output the bucket name and ARN
output "bucket_name" {
  value       = aws_s3_bucket.help_logs_bucket.id
  description = "The name of the bucket"
}

output "bucket_arn" {
  value       = aws_s3_bucket.help_logs_bucket.arn
  description = "The ARN of the bucket"
}
```

This configuration:
1. Creates an S3 bucket named "help-log-live"
2. Enables versioning for object version control
3. Configures server-side encryption using AES256
4. Blocks all public access to the bucket
5. Enables access logging (stored in the same bucket under 'access-logs/' prefix)
6. Adds prevent_destroy lifecycle policy
7. Includes relevant tags for resource management
8. Provides outputs for bucket name and ARN

Security features included:
- Server-side encryption enabled
- All public access blocked
- Access logging enabled
- Versioning enabled for data protection
- Prevent accidental deletion

To deploy:
1. Save this configuration in a `.tf` file
2. Run `terraform init` to initialize
3. Run `terraform plan` to review changes
4. Run `terraform apply` to create the bucket

Remember that S3 bucket names must be globally unique across all AWS accounts. If "help-log-live" is already taken, you'll need to choose a different name.

**Terraform Code:**
```hcl
# Configure AWS Provider
provider "aws" {
  region = "us-east-1"
}

# Create S3 Bucket with versioning and encryption
resource "aws_s3_bucket" "help_logs_bucket" {
  bucket = "help-log-live"

  # Prevent accidental deletion of this S3 bucket
  lifecycle {
    prevent_destroy = true
  }

  tags = {
    Name        = "help-log-live"
    Environment = "production"
    Purpose     = "Logging"
    Managed_by  = "Terraform"
  }
}

# Enable versioning
resource "aws_s3_bucket_versioning" "help_logs_bucket_versioning" {
  bucket = aws_s3_bucket.help_logs_bucket.id
  versioning_configuration {
    status = "Enabled"
  }
}

# Enable server-side encryption
resource "aws_s3_bucket_server_side_encryption_configuration" "help_logs_bucket_encryption" {
  bucket = aws_s3_bucket.help_logs_bucket.id

  rule {
    apply_server_side_encryption_by_default {
      sse_algorithm = "AES256"
    }
  }
}

# Block public access
resource "aws_s3_bucket_public_access_block" "help_logs_bucket_public_access_block" {
  bucket = aws_s3_bucket.help_logs_bucket.id

  block_public_acls       = true
  block_public_policy     = true
  ignore_public_acls      = true
  restrict_public_buckets = true
}

# Enable logging for bucket access
resource "aws_s3_bucket_logging" "help_logs_bucket_logging" {
  bucket = aws_s3_bucket.help_logs_bucket.id

  target_bucket = aws_s3_bucket.help_logs_bucket.id
  target_prefix = "access-logs/"
}

# Output the bucket name and ARN
output "bucket_name" {
  value       = aws_s3_bucket.help_logs_bucket.id
  description = "The name of the bucket"
}

output "bucket_arn" {
  value       = aws_s3_bucket.help_logs_bucket.arn
  description = "The ARN of the bucket"
}
```