### PR TITLE
Infrastructure: I'll help you create an S3 bucket named "test-2" with appropriate security configurations. Note that...

### DIFF
--- a/configs/infrastructure/main.tf
+++ b/configs/infrastructure/main.tf
@@ -1,14 +1,12 @@
 # Configure AWS Provider
-provider "aws" {
-  region = "us-east-1"
-}
+provider "aws" {}
 
 # Create S3 Bucket
 resource "aws_s3_bucket" "test_bucket" {
-  bucket = "test-12345"
+  bucket = "test-2"
 
   tags = {
-    Name        = "test-12345"
+    Name        = "test-2"
     Environment = "test"
     Managed_by  = "Terraform"
     Created_at  = timestamp()
@@ -44,23 +42,16 @@ resource "aws_s3_bucket_public_access_block" "test_bucket_public_access_block" {
   restrict_public_buckets = true
 }
 
-# Add lifecycle rule for test environment
+# Add basic lifecycle rule for test environment
 resource "aws_s3_bucket_lifecycle_configuration" "test_bucket_lifecycle" {
   bucket = aws_s3_bucket.test_bucket.id
 
   rule {
-    id     = "cleanup_test_files"
+    id     = "test_environment_cleanup"
     status = "Enabled"
 
-    # Move files to Standard-IA after 30 days
-    transition {
-      days          = 30
-      storage_class = "STANDARD_IA"
-    }
-
-    # Delete files after 90 days
     expiration {
-      days = 90
+      days = 90  # Delete files after 90 days
     }
 
     # Clean up incomplete multipart uploads
@@ -81,7 +72,7 @@ output "bucket_arn" {
   description = "The ARN of the bucket"
 }
 
-output "bucket_region" {
-  value       = aws_s3_bucket.test_bucket.region
-  description = "The region where the bucket is created"
+output "bucket_domain_name" {
+  value       = aws_s3_bucket.test_bucket.bucket_domain_name
+  description = "The bucket domain name"
 }


### PR DESCRIPTION
This PR contains Terraform infrastructure generated by the IAC AI assistant.

**Generated from conversation:** I'll help you create an S3 bucket named "test-2" with appropriate security configurations. Note that S3 is a global service, so we don't need to specify a region in the provider configuration.

```hcl
# Configure AWS Provider
provider "aws" {}

# Create S3 Bucket
resource "aws_s3_bucket" "test_bucket" {
  bucket = "test-2"

  tags = {
    Name        = "test-2"
    Environment = "test"
    Managed_by  = "Terraform"
    Created_at  = timestamp()
  }
}

# Enable versioning
resource "aws_s3_bucket_versioning" "test_bucket_versioning" {
  bucket = aws_s3_bucket.test_bucket.id
  versioning_configuration {
    status = "Enabled"
  }
}

# Enable server-side encryption
resource "aws_s3_bucket_server_side_encryption_configuration" "test_bucket_encryption" {
  bucket = aws_s3_bucket.test_bucket.id

  rule {
    apply_server_side_encryption_by_default {
      sse_algorithm = "AES256"
    }
  }
}

# Block public access
resource "aws_s3_bucket_public_access_block" "test_bucket_public_access_block" {
  bucket = aws_s3_bucket.test_bucket.id

  block_public_acls       = true
  block_public_policy     = true
  ignore_public_acls      = true
  restrict_public_buckets = true
}

# Add basic lifecycle rule for test environment
resource "aws_s3_bucket_lifecycle_configuration" "test_bucket_lifecycle" {
  bucket = aws_s3_bucket.test_bucket.id

  rule {
    id     = "test_environment_cleanup"
    status = "Enabled"

    expiration {
      days = 90  # Delete files after 90 days
    }

    # Clean up incomplete multipart uploads
    abort_incomplete_multipart_upload {
      days_after_initiation = 7
    }
  }
}

# Output the bucket details
output "bucket_name" {
  value       = aws_s3_bucket.test_bucket.id
  description = "The name of the bucket"
}

output "bucket_arn" {
  value       = aws_s3_bucket.test_bucket.arn
  description = "The ARN of the bucket"
}

output "bucket_domain_name" {
  value       = aws_s3_bucket.test_bucket.bucket_domain_name
  description = "The bucket domain name"
}
```

This configuration creates an S3 bucket with:

1. Basic bucket configuration
2. Versioning enabled
3. Server-side encryption using AES256
4. Public access blocking
5. Basic lifecycle rules appropriate for a test environment
6. Comprehensive tagging
7. Important outputs

Security features:
- Encryption at rest enabled
- All public access blocked
- Versioning enabled
- Automatic cleanup of incomplete multipart uploads
- 90-day retention policy for test files

To deploy:
1. Save this configuration in a `.tf` file
2. Run `terraform init` to initialize
3. Run `terraform plan` to review changes
4. Run `terraform apply` to create the bucket

Note:
- S3 is a global service, so we don't need to specify a region in the provider block
- The bucket name must be globally unique across all AWS accounts
- The configuration includes basic security best practices suitable for a test environment
- Lifecycle rules are set to clean up test data after 90 days to manage costs
- All public access is blocked by default for security

**Terraform Code:**
```hcl
# Configure AWS Provider
provider "aws" {}

# Create S3 Bucket
resource "aws_s3_bucket" "test_bucket" {
  bucket = "test-2"

  tags = {
    Name        = "test-2"
    Environment = "test"
    Managed_by  = "Terraform"
    Created_at  = timestamp()
  }
}

# Enable versioning
resource "aws_s3_bucket_versioning" "test_bucket_versioning" {
  bucket = aws_s3_bucket.test_bucket.id
  versioning_configuration {
    status = "Enabled"
  }
}

# Enable server-side encryption
resource "aws_s3_bucket_server_side_encryption_configuration" "test_bucket_encryption" {
  bucket = aws_s3_bucket.test_bucket.id

  rule {
    apply_server_side_encryption_by_default {
      sse_algorithm = "AES256"
    }
  }
}

# Block public access
resource "aws_s3_bucket_public_access_block" "test_bucket_public_access_block" {
  bucket = aws_s3_bucket.test_bucket.id

  block_public_acls       = true
  block_public_policy     = true
  ignore_public_acls      = true
  restrict_public_buckets = true
}

# Add basic lifecycle rule for test environment
resource "aws_s3_bucket_lifecycle_configuration" "test_bucket_lifecycle" {
  bucket = aws_s3_bucket.test_bucket.id

  rule {
    id     = "test_environment_cleanup"
    status = "Enabled"

    expiration {
      days = 90  # Delete files after 90 days
    }

    # Clean up incomplete multipart uploads
    abort_incomplete_multipart_upload {
      days_after_initiation = 7
    }
  }
}

# Output the bucket details
output "bucket_name" {
  value       = aws_s3_bucket.test_bucket.id
  description = "The name of the bucket"
}

output "bucket_arn" {
  value       = aws_s3_bucket.test_bucket.arn
  description = "The ARN of the bucket"
}

output "bucket_domain_name" {
  value       = aws_s3_bucket.test_bucket.bucket_domain_name
  description = "The bucket domain name"
}
```