### PR TITLE
Infrastructure: I'll help you create an S3 bucket named "test-new-repo-new-config-new-mod" with security best practi...

### DIFF
--- a/configs/infrastructure/main.tf
+++ b/configs/infrastructure/main.tf
@@ -1,15 +1,12 @@
-# Configure AWS Provider
-# Note: Since S3 is a global service, we don't technically need a region,
-# but including it for consistency with other AWS resources
-provider "aws" {
-}
+# Configure AWS Provider (no region needed for S3 as it's a global service)
+provider "aws" {}
 
 # Create S3 Bucket
-resource "aws_s3_bucket" "test_logic_bucket" {
-  bucket = "test-new-logic-13442"
+resource "aws_s3_bucket" "test_repo_bucket" {
+  bucket = "test-new-repo-new-config-new-mod"
 
   tags = {
-    Name        = "test-new-logic-13442"
+    Name        = "test-new-repo-new-config-new-mod"
     Environment = "test"
     Managed_by  = "Terraform"
     Created_at  = timestamp()
@@ -17,16 +14,16 @@ resource "aws_s3_bucket" "test_logic_bucket" {
 }
 
 # Enable versioning
-resource "aws_s3_bucket_versioning" "test_logic_bucket_versioning" {
-  bucket = aws_s3_bucket.test_logic_bucket.id
+resource "aws_s3_bucket_versioning" "test_repo_bucket_versioning" {
+  bucket = aws_s3_bucket.test_repo_bucket.id
   versioning_configuration {
     status = "Enabled"
   }
 }
 
 # Enable server-side encryption
-resource "aws_s3_bucket_server_side_encryption_configuration" "test_logic_bucket_encryption" {
-  bucket = aws_s3_bucket.test_logic_bucket.id
+resource "aws_s3_bucket_server_side_encryption_configuration" "test_repo_bucket_encryption" {
+  bucket = aws_s3_bucket.test_repo_bucket.id
 
   rule {
     apply_server_side_encryption_by_default {
@@ -36,8 +33,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "test_logic_bucket
 }
 
 # Block public access
-resource "aws_s3_bucket_public_access_block" "test_logic_bucket_public_access_block" {
-  bucket = aws_s3_bucket.test_logic_bucket.id
+resource "aws_s3_bucket_public_access_block" "test_repo_bucket_public_access_block" {
+  bucket = aws_s3_bucket.test_repo_bucket.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -45,15 +42,23 @@ resource "aws_s3_bucket_public_access_block" "test_logic_bucket_public_access_bl
   restrict_public_buckets = true
 }
 
+# Enable access logging
+resource "aws_s3_bucket_logging" "test_repo_bucket_logging" {
+  bucket = aws_s3_bucket.test_repo_bucket.id
+
+  target_bucket = aws_s3_bucket.test_repo_bucket.id
+  target_prefix = "access-logs/"
+}
+
 # Add lifecycle rules for test environment
-resource "aws_s3_bucket_lifecycle_configuration" "test_logic_bucket_lifecycle" {
-  bucket = aws_s3_bucket.test_logic_bucket.id
+resource "aws_s3_bucket_lifecycle_configuration" "test_repo_bucket_lifecycle" {
+  bucket = aws_s3_bucket.test_repo_bucket.id
 
   rule {
-    id     = "test_cleanup"
+    id     = "test_environment_cleanup"
     status = "Enabled"
 
-    # Move files to cheaper storage after 30 days
+    # Move files to Standard-IA after 30 days
     transition {
       days          = 30
       storage_class = "STANDARD_IA"
@@ -64,9 +69,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "test_logic_bucket_lifecycle" {
       days = 90
     }
 
-    # Clean up incomplete multipart uploads
-    abort_incomplete_multipart_upload {
-      days_after_initiation = 7
+    # Clean up old versions after 30 days
+    noncurrent_version_expiration {
+      noncurrent_days = 30
     }
   }
 }

--- a/configs/infrastructure/outputs.tf
+++ b/configs/infrastructure/outputs.tf
@@ -2,21 +2,21 @@
 # This file contains all output values from the Terraform configuration
 
 output "bucket_name" {
-  value       = aws_s3_bucket.test_logic_bucket.id
+  value       = aws_s3_bucket.test_repo_bucket.id
   description = "The name of the bucket"
 }
 
 output "bucket_arn" {
-  value       = aws_s3_bucket.test_logic_bucket.arn
+  value       = aws_s3_bucket.test_repo_bucket.arn
   description = "The ARN of the bucket"
 }
 
 output "bucket_domain_name" {
-  value       = aws_s3_bucket.test_logic_bucket.bucket_domain_name
+  value       = aws_s3_bucket.test_repo_bucket.bucket_domain_name
   description = "The bucket domain name"
 }
 
 output "bucket_regional_domain_name" {
-  value       = aws_s3_bucket.test_logic_bucket.bucket_regional_domain_name
+  value       = aws_s3_bucket.test_repo_bucket.bucket_regional_domain_name
   description = "The bucket region-specific domain name"
 }


### PR DESCRIPTION
This PR contains Terraform infrastructure generated by the IAC AI assistant.

**Generated from conversation:** I'll help you create an S3 bucket named "test-new-repo-new-config-new-mod" with security best practices. Since S3 is a global service, we don't need to specify a region in the provider block.

```hcl
# Configure AWS Provider (no region needed for S3 as it's a global service)
provider "aws" {}

# Create S3 Bucket
resource "aws_s3_bucket" "test_repo_bucket" {
  bucket = "test-new-repo-new-config-new-mod"

  tags = {
    Name        = "test-new-repo-new-config-new-mod"
    Environment = "test"
    Managed_by  = "Terraform"
    Created_at  = timestamp()
  }
}

# Enable versioning
resource "aws_s3_bucket_versioning" "test_repo_bucket_versioning" {
  bucket = aws_s3_bucket.test_repo_bucket.id
  versioning_configuration {
    status = "Enabled"
  }
}

# Enable server-side encryption
resource "aws_s3_bucket_server_side_encryption_configuration" "test_repo_bucket_encryption" {
  bucket = aws_s3_bucket.test_repo_bucket.id

  rule {
    apply_server_side_encryption_by_default {
      sse_algorithm = "AES256"
    }
  }
}

# Block public access
resource "aws_s3_bucket_public_access_block" "test_repo_bucket_public_access_block" {
  bucket = aws_s3_bucket.test_repo_bucket.id

  block_public_acls       = true
  block_public_policy     = true
  ignore_public_acls      = true
  restrict_public_buckets = true
}

# Enable access logging
resource "aws_s3_bucket_logging" "test_repo_bucket_logging" {
  bucket = aws_s3_bucket.test_repo_bucket.id

  target_bucket = aws_s3_bucket.test_repo_bucket.id
  target_prefix = "access-logs/"
}

# Add lifecycle rules for test environment
resource "aws_s3_bucket_lifecycle_configuration" "test_repo_bucket_lifecycle" {
  bucket = aws_s3_bucket.test_repo_bucket.id

  rule {
    id     = "test_environment_cleanup"
    status = "Enabled"

    # Move files to Standard-IA after 30 days
    transition {
      days          = 30
      storage_class = "STANDARD_IA"
    }

    # Delete files after 90 days
    expiration {
      days = 90
    }

    # Clean up old versions after 30 days
    noncurrent_version_expiration {
      noncurrent_days = 30
    }
  }
}

# Output the bucket details
output "bucket_name" {
  value       = aws_s3_bucket.test_repo_bucket.id
  description = "The name of the bucket"
}

output "bucket_arn" {
  value       = aws_s3_bucket.test_repo_bucket.arn
  description = "The ARN of the bucket"
}

output "bucket_domain_name" {
  value       = aws_s3_bucket.test_repo_bucket.bucket_domain_name
  description = "The bucket domain name"
}

output "bucket_regional_domain_name" {
  value       = aws_s3_bucket.test_repo_bucket.bucket_regional_domain_name
  description = "The bucket region-specific domain name"
}
```

This configuration creates an S3 bucket with:

1. Basic bucket configuration
2. Versioning enabled for object version control
3. Server-side encryption using AES256
4. Complete public access blocking
5. Access logging enabled
6. Lifecycle rules appropriate for a test environment:
   - Move files to Standard-IA after 30 days (cost optimization)
   - Delete files after 90 days
   - Remove old versions after 30 days
7. Comprehensive tagging including creation timestamp
8. Detailed outputs

Security features:
- Encryption at rest enabled
- All public access blocked
- Access logging enabled
- Versioning enabled
- Automated cleanup for test data

To deploy:
1. Save this configuration in a `.tf` file
2. Run `terraform init` to initialize
3. Run `terraform plan` to review changes
4. Run `terraform apply` to create the bucket

Note:
- S3 is a global service, so we don't need to specify a region in the provider block
- The bucket name must be globally unique across all AWS accounts
- The lifecycle rules are set up for a test environment; adjust the timing if needed
- Access logs are stored in the same bucket under the 'access-logs/' prefix

**Files created:**
- `main.tf` - Main Terraform configuration
- `variables.tf` - Input variables
- `outputs.tf` - Output values

**Terraform Code:**
```hcl
# Configure AWS Provider (no region needed for S3 as it's a global service)
provider "aws" {}

# Create S3 Bucket
resource "aws_s3_bucket" "test_repo_bucket" {
  bucket = "test-new-repo-new-config-new-mod"

  tags = {
    Name        = "test-new-repo-new-config-new-mod"
    Environment = "test"
    Managed_by  = "Terraform"
    Created_at  = timestamp()
  }
}

# Enable versioning
resource "aws_s3_bucket_versioning" "test_repo_bucket_versioning" {
  bucket = aws_s3_bucket.test_repo_bucket.id
  versioning_configuration {
    status = "Enabled"
  }
}

# Enable server-side encryption
resource "aws_s3_bucket_server_side_encryption_configuration" "test_repo_bucket_encryption" {
  bucket = aws_s3_bucket.test_repo_bucket.id

  rule {
    apply_server_side_encryption_by_default {
      sse_algorithm = "AES256"
    }
  }
}

# Block public access
resource "aws_s3_bucket_public_access_block" "test_repo_bucket_public_access_block" {
  bucket = aws_s3_bucket.test_repo_bucket.id

  block_public_acls       = true
  block_public_policy     = true
  ignore_public_acls      = true
  restrict_public_buckets = true
}

# Enable access logging
resource "aws_s3_bucket_logging" "test_repo_bucket_logging" {
  bucket = aws_s3_bucket.test_repo_bucket.id

  target_bucket = aws_s3_bucket.test_repo_bucket.id
  target_prefix = "access-logs/"
}

# Add lifecycle rules for test environment
resource "aws_s3_bucket_lifecycle_configuration" "test_repo_bucket_lifecycle" {
  bucket = aws_s3_bucket.test_repo_bucket.id

  rule {
    id     = "test_environment_cleanup"
    status = "Enabled"

    # Move files to Standard-IA after 30 days
    transition {
      days          = 30
      storage_class = "STANDARD_IA"
    }

    # Delete files after 90 days
    expiration {
      days = 90
    }

    # Clean up old versions after 30 days
    noncurrent_version_expiration {
      noncurrent_days = 30
    }
  }
}

# Output the bucket details
output "bucket_name" {
  value       = aws_s3_bucket.test_repo_bucket.id
  description = "The name of the bucket"
}

output "bucket_arn" {
  value       = aws_s3_bucket.test_repo_bucket.arn
  description = "The ARN of the bucket"
}

output "bucket_domain_name" {
  value       = aws_s3_bucket.test_repo_bucket.bucket_domain_name
  description = "The bucket domain name"
}

output "bucket_regional_domain_name" {
  value       = aws_s3_bucket.test_repo_bucket.bucket_regional_domain_name
  description = "The bucket region-specific domain name"
}
```